### PR TITLE
Only Run sortSetFieldSelectors when we have field or column field data

### DIFF
--- a/src/modules/list-view-grid/list-view-grid.component.ts
+++ b/src/modules/list-view-grid/list-view-grid.component.ts
@@ -220,12 +220,13 @@ export class SkyListViewGridComponent
       .map(s => s.sort.fieldSelectors.filter(f => f.fieldSelector === column.field)[0])
       .take(1)
       .subscribe(field => {
-        let selectors = [`${column.field}:DESC`];
         if (field) {
-          selectors = [`${field.fieldSelector}:${field.descending ? 'ASC' : 'DESC'}`];
+          this.dispatcher.sortSetFieldSelectors(
+            [`${field.fieldSelector}:${field.descending ? 'ASC' : 'DESC'}`]
+          );
+        } else if (column.field) {
+          this.dispatcher.sortSetFieldSelectors([`${column.field}:DESC`]);
         }
-
-        this.dispatcher.sortSetFieldSelectors(selectors);
       });
   }
 


### PR DESCRIPTION
First part of bug fix for not allowing sorting on field-less columns with a template. A @blackbaud-brandonstirnaman co-production. 