### PR TITLE
address skyux-cli linting issues

### DIFF
--- a/src/modules/i18n/index.ts
+++ b/src/modules/i18n/index.ts
@@ -3,10 +3,10 @@ import { EN_AU } from './locale.en_AU';
 import { EN_GB } from './locale.en_GB';
 import { EN_CA } from './locale.en_CA';
 
-let dict = {};
+let dict: any = {};
 dict['en-us'] = EN_US;
 dict['en-au'] = EN_AU;
 dict['en-gb'] = EN_GB;
 dict['en-ca'] = EN_CA;
 
-export let translationDict = dict;
+export let translationDict: any = dict;

--- a/src/modules/i18n/locale.en_AU.ts
+++ b/src/modules/i18n/locale.en_AU.ts
@@ -1,6 +1,6 @@
 import { EN_US } from './locale.en_US';
 
-export var EN_AU = Object.assign({}, EN_US, {
+export let EN_AU: any = Object.assign({}, EN_US, {
   // tabs / general //
   HELLO: 'hello world - en-AU'
 });

--- a/src/modules/i18n/locale.en_CA.ts
+++ b/src/modules/i18n/locale.en_CA.ts
@@ -1,6 +1,6 @@
 import { EN_US } from './locale.en_US';
 
-export var EN_CA = Object.assign({}, EN_US, {
+export let EN_CA: any = Object.assign({}, EN_US, {
   // tabs / general //
   HELLO: 'hello world - en-CA'
 });

--- a/src/modules/i18n/locale.en_GB.ts
+++ b/src/modules/i18n/locale.en_GB.ts
@@ -1,6 +1,6 @@
 import { EN_US } from './locale.en_US';
 
-export var EN_GB = Object.assign({}, EN_US, {
+export let EN_GB: any = Object.assign({}, EN_US, {
   // tabs / general //
   HELLO: 'hello world - en-GB'
 });

--- a/src/modules/i18n/locale.en_US.ts
+++ b/src/modules/i18n/locale.en_US.ts
@@ -1,4 +1,4 @@
-export let EN_US = {
+export let EN_US: any = {
   // tabs / general //
   LOADING_TEXT: 'Loading...',
   HELLO: 'hello world - en-US',

--- a/src/modules/list-view-grid/list-view-grid.component.ts
+++ b/src/modules/list-view-grid/list-view-grid.component.ts
@@ -23,7 +23,8 @@ import { DragulaService } from 'ng2-dragula/ng2-dragula';
 import { SkyModalService } from '@blackbaud/skyux/dist/core';
 import { getValue } from 'microedge-rxstate/dist/helpers';
 import { getData } from '../list/helpers';
-import { ListItemModel } from '../list/state/items/item.model';
+import { ListItemModel } from "../list/state/items/item.model";
+import { ListSelectedModel } from "../list/state/selected/selected.model";
 
 @Component({
   selector: 'sky-contrib-list-view-grid',
@@ -286,7 +287,8 @@ export class SkyContribListViewGridComponent
     return Observable.combineLatest(
       this.items.distinctUntilChanged(),
       this.state.map(s => s.selected.item).distinctUntilChanged(),
-      (items: any, selected: ListItemModel) => items.every((i: any) => selected[i.id] != null)
+      (items: Array<ListItemModel>, selected: ListSelectedModel) =>
+        items.every((i: ListItemModel) => selected[i.id] != null)
     ).distinctUntilChanged();
   }
 }


### PR DESCRIPTION
Addresses the following `skyux-cli` linting issues when running the `build` command.

```
ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/locale/locale.service.ts (13,47): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/locale/locale.service.ts (14,47): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/locale/locale.service.ts (15,47): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/locale/locale.service.ts (16,47): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/locale/locale.service.ts (52,10): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/i18n/index.ts (7,1): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/i18n/index.ts (8,1): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/i18n/index.ts (9,1): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/i18n/index.ts (10,1): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/translation/translate.service.ts (23,9): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/translation/translate.service.ts (24,39): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/translation/translate.service.ts (26,7): Element implicitly has an 'any' type because type '{}' has no index signature.

ERROR in D:/skyux-spa-donorcentral-support/node_modules/microedge-skyux2-contrib/dist/modules/list-view-grid/list-view-grid.component.ts (288,72): Element implicitly has an 'any' type because type 'ListItemModel' has no index signature.

```